### PR TITLE
Splash Screen, auto-login, and bug fix

### DIFF
--- a/lib/app/components/countdown.dart
+++ b/lib/app/components/countdown.dart
@@ -275,4 +275,10 @@ class CountdownState extends State<Countdown> {
       ],
     );
   }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
 }

--- a/lib/app/components/hhDrawer.dart
+++ b/lib/app/components/hhDrawer.dart
@@ -44,7 +44,7 @@ class HhDrawer extends StatelessWidget {
             Icons.map,
             size: 22.0,
           ),
-          onTap: () => Navigator.of(context).pushReplacementNamed('/home'),
+          onTap: () => navigate('/home', context),
         ),
         ListTile(
           title: Text(
@@ -55,7 +55,7 @@ class HhDrawer extends StatelessWidget {
             Icons.map,
             size: 22.0,
           ),
-          onTap: () => Navigator.of(context).pushReplacementNamed('/map'),
+          onTap: () => navigate('/map', context),
         ),
         ListTile(
           title: Text(
@@ -141,5 +141,9 @@ class HhDrawer extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  void navigate(String page, context) {
+    Navigator.of(context).pushReplacementNamed(page);
   }
 }

--- a/lib/app/home/home_view.dart
+++ b/lib/app/home/home_view.dart
@@ -165,7 +165,6 @@ class HomePageView extends View<HomePage> {
   @override
   void dispose() {
     _controller.dispose();
-    _stopTimer = true;
     super.dispose();
   }
 }

--- a/lib/app/home/home_view.dart
+++ b/lib/app/home/home_view.dart
@@ -165,6 +165,7 @@ class HomePageView extends View<HomePage> {
   @override
   void dispose() {
     _controller.dispose();
+    _stopTimer = true;
     super.dispose();
   }
 }

--- a/lib/app/main.dart
+++ b/lib/app/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hnh/app/map/map_view.dart';
+import 'package:hnh/app/splash/splash_view.dart';
 import 'package:logging/logging.dart';
 import 'home/home_view.dart';
 import 'login/login_view.dart';
@@ -48,7 +49,7 @@ class MyApp extends StatelessWidget {
                 TextStyle(fontWeight: FontWeight.w300, color: Colors.black),
           ),
         ),
-        home: LoginPage(title: "Hotter'n Hell"),
+        home: SplashPage(),
         debugShowCheckedModeBanner: false,
         routes: <String, WidgetBuilder>{
           '/home': (BuildContext context) => new HomePage(),

--- a/lib/app/splash/splash_controller.dart
+++ b/lib/app/splash/splash_controller.dart
@@ -1,12 +1,47 @@
+import 'package:flutter/animation.dart';
 import 'package:hnh/app/abstract/controller.dart';
 import 'package:hnh/app/splash/splash_presenter.dart';
+import 'package:flutter/material.dart';
 
 class SplashController extends Controller {
   SplashPresenter _splashPresenter;
-
-  SplashController() {
+  
+  SplashController(authRepo) {
+    _splashPresenter = SplashPresenter(authRepo);
     initListeners();
+    getAuthStatus();
   }
 
-  void initListeners() {}
+  /// Initializes [animation] for the view using a given [controller]
+  void initAnimation(AnimationController controller, Animation animation) {
+    animation.addStatusListener((status) {
+      if (!isLoading) {
+        controller.stop(canceled: true);
+      } else if (status == AnimationStatus.completed) {
+        controller.reverse();
+
+      } else if (status == AnimationStatus.dismissed){
+        controller.forward();
+      }
+    });
+    controller.forward();
+  }
+
+  void authStatusOnNext(bool isAuth) {
+    String page = isAuth ? '/home' : '/login';
+    Navigator.of(context).pushReplacementNamed(page);
+  }
+
+  void getAuthStatus() async {
+    isLoading = true;
+    // so the animation can be seen
+    Future.delayed(Duration(seconds: 3), _splashPresenter.getAuthStatus);
+  }
+
+  void initListeners() {
+    _splashPresenter.getAuthStatusOnNext = authStatusOnNext;
+    _splashPresenter.getAuthStatusOnComplete = () => dismissLoading();
+  }
+
+  void dispose() => _splashPresenter.dispose();
 }

--- a/lib/app/splash/splash_presenter.dart
+++ b/lib/app/splash/splash_presenter.dart
@@ -1,19 +1,38 @@
 import 'package:hnh/domain/usecases/observer.dart';
+import 'package:hnh/domain/usecases/auth/get_authentication_status_usecase.dart';
 
 class SplashPresenter {
-  Function splashOnComplete;
-  Function splashOnError;
+  Function getAuthStatusOnNext;
+  Function getAuthStatusOnComplete;
 
-  SplashPresenter();
+  GetAuthStatusUseCase _getAuthStatusUseCase;
+
+  SplashPresenter(authRepo) {
+    _getAuthStatusUseCase = GetAuthStatusUseCase(authRepo);
+  }
+
+  void getAuthStatus() => _getAuthStatusUseCase.execute(_SplashObserver(this));
+  void dispose() => _getAuthStatusUseCase.dispose();
 }
 
-class _SplashObserver implements Observer<void> {
+class _SplashObserver implements Observer<bool> {
   SplashPresenter _splashPresenter;
   _SplashObserver(this._splashPresenter);
 
-  void onNext(ignore) {}
+  void onNext(isAuth) {
+    assert (_splashPresenter.getAuthStatusOnNext != null);
+    _splashPresenter.getAuthStatusOnNext(isAuth);
+  }
 
-  void onComplete() {}
+  void onComplete() {
+    assert (_splashPresenter.getAuthStatusOnComplete != null);
+    _splashPresenter.getAuthStatusOnComplete();
+  }
 
-  void onError(e) {}
+  void onError(e) {
+    // if any errors occured, proceed as if the user is not logged in
+    assert (_splashPresenter.getAuthStatusOnNext != null);
+    _splashPresenter.getAuthStatusOnNext(false);
+    onComplete();
+  }
 }

--- a/lib/app/splash/splash_view.dart
+++ b/lib/app/splash/splash_view.dart
@@ -1,38 +1,77 @@
 import 'package:flutter/material.dart';
 import 'package:hnh/app/abstract/view.dart';
 import 'package:hnh/app/splash/splash_controller.dart';
+import 'package:hnh/app/utils/constants.dart';
+import 'package:hnh/data/repositories/data_authentication_repository.dart';
 
 class SplashPage extends StatefulWidget {
   SplashPage();
-
   @override
-  SplashPageView createState() => SplashPageView(SplashController());
+  SplashPageView createState() => SplashPageView(SplashController(DataAuthenticationRepository()));
 }
 
-class SplashPageView extends View<SplashPage> with SingleTickerProviderStateMixin{
-
+class SplashPageView extends View<SplashPage> with SingleTickerProviderStateMixin {
   SplashController _controller;
 
   AnimationController _animationController;
+  Animation<double> _animation;
 
   SplashPageView(this._controller);
 
   @override
   void initState() {
     super.initState();
-    _animationController = AnimationController(vsync: this);
+    _animationController = AnimationController(vsync: this, duration: Duration(seconds: 1));
+    _animation = CurvedAnimation(parent: _animationController, curve: Curves.easeIn);
+    _controller.initAnimation(_animationController, _animation);
+     _controller.refresh = callHandler;
   }
 
   @override
   void dispose() {
-    super.dispose();
     _animationController.dispose();
+    _controller.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      
-    );
+    _controller.context = context;
+    return Scaffold(body: body);
   }
+
+  // Scaffold body
+  Stack get body => Stack(
+        children: <Widget>[
+          background,
+          logo,
+        ],
+      );
+
+  Positioned get background => Positioned(
+        top: 0.0,
+        left: 0.0,
+        right: 0.0,
+        height: MediaQuery.of(context).size.height,
+        child: Image.asset(
+          Resources.background,
+          fit: BoxFit.cover,
+        ),
+      );
+
+  Positioned get logo => Positioned(
+        top: MediaQuery.of(context).size.height / 2 - 50,
+        left: 0.0,
+        right: 0.0,
+        child: Column(
+          children: <Widget>[
+            FadeTransition(
+                opacity: _animation,
+                child: Image(
+                  image: AssetImage(Resources.logo),
+                  width: 200.0,
+                )),
+          ],
+        ),
+      );
 }

--- a/lib/data/repositories/data_authentication_repository.dart
+++ b/lib/data/repositories/data_authentication_repository.dart
@@ -72,7 +72,7 @@ class DataAuthenticationRepository implements AuthenticationRepository {
     try {
       SharedPreferences preferences = await SharedPreferences.getInstance();
       bool isAuthenticated = preferences.getBool(Constants.isAuthenticatedKey);
-      return isAuthenticated;
+      return isAuthenticated ?? false;
     } catch (error) {
       return false;
     }


### PR DESCRIPTION
* Created `SplashPage` and its `Controller` and `Presenter`
* Checked for authentication during splash and navigated to either `login` or `home` accordingly
* Implemented animation in `SplashPage`
* Fixed a Bug that allowed `Countdown` to keep counting down after parent page was disposed.